### PR TITLE
Add support for parser filter.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update -y && apt-get install -yy \
       fluent-plugin-multi-format-parser:0.0.2 \
       fluent-plugin-kinesis-aggregation:0.2.2 \
       fluent-plugin-concat:0.4.0 \
+      fluent-plugin-parser:0.6.1 \
       fluent-plugin-statsd-event:0.1.1 && \
     apt-get purge -y build-essential && \
     apt-get autoremove -y && \


### PR DESCRIPTION
filter_parser is included in Fluentd’s core since v0.12.29 but given we're running a slightly earlier version, the plugin needs to be installed separately.