### PR TITLE
Update to fluentd 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,17 +10,15 @@ RUN apt-get update -y && apt-get install -yy \
       build-essential \
       zlib1g-dev \
       libjemalloc1 && \
-    gem install fluentd:0.12.23 && \
+    gem install fluentd:0.14.21 && \
     gem install google-protobuf -v 3.0.0.alpha.4.0 --pre && \
       fluent-gem install \
-      fluent-plugin-ec2-metadata:0.0.9 \
       fluent-plugin-hostname:0.0.2 \
       fluent-plugin-retag:0.0.1 \
-      fluent-plugin-kinesis:1.0.1 \
       fluent-plugin-elasticsearch:1.4.0 \
       fluent-plugin-record-modifier:0.4.1 \
       fluent-plugin-multi-format-parser:0.0.2 \
-      fluent-plugin-kinesis-aggregation:0.2.2 \
+      fluent-plugin-kinesis-aggregation:0.3.0 \
       fluent-plugin-concat:0.4.0 \
       fluent-plugin-parser:0.6.1 \
       fluent-plugin-statsd-event:0.1.1 && \


### PR DESCRIPTION
* Use latest fluentd version
* Update kinesis-aggregation to version that works with fluentd 14
* Remove unneeded kinesis plugin (replaced by kinesis-aggregration)
* Remove ec2-metadata-plugin due to conflicts it introduces by not pinning the ruby AWS SDK
* Will require removing references to ec2 metadata plugin