### PR TITLE
Bump versions of fluentd and fluent-plugin-kinesis-aggregation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -y && apt-get install -yy \
       build-essential \
       zlib1g-dev \
       libjemalloc1 && \
-    gem install fluentd:0.12.23 && \
+    gem install fluentd:0.14.25 && \
     gem install google-protobuf -v 3.0.0.alpha.4.0 --pre && \
       fluent-gem install \
       fluent-plugin-ec2-metadata:0.0.9 \
@@ -20,7 +20,7 @@ RUN apt-get update -y && apt-get install -yy \
       fluent-plugin-elasticsearch:1.4.0 \
       fluent-plugin-record-modifier:0.4.1 \
       fluent-plugin-multi-format-parser:0.0.2 \
-      fluent-plugin-kinesis-aggregation:0.2.2 \
+      fluent-plugin-kinesis-aggregation:0.3.0 \
       fluent-plugin-concat:0.4.0 \
       fluent-plugin-parser:0.6.1 \
       fluent-plugin-statsd-event:0.1.1 && \

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,11 @@
 
 GIT_HASH := $(shell git --no-pager show --format=%h --no-patch)
 BUILD_DATE := $(shell date +%Y%m%d-%H%M%S)
-BRANCH := $(shell git symbolic-ref --short HEAD)
 
-IS_DIRTY := $(shell ! [[ -z "$(git status --porcelain 2> /dev/null)" ]] && echo "-dirty")
 VERSION := ${GIT_HASH}${IS_DIRTY}
-TAG ?= ${VERSION}
 
 IMAGE_REPOSITORY := atlassianlabs/fluentd
-IMAGE_REFERENCE := ${IMAGE_REPOSITORY}:$(TAG)
+IMAGE_REFERENCE := ${IMAGE_REPOSITORY}:$(tag)
 
 help: ### Dumps out all the target lines with suffixed comments
 	@cat < $(MAKEFILE_LIST) \
@@ -18,11 +15,16 @@ help: ### Dumps out all the target lines with suffixed comments
 		| column -t -s'|||'
 
 build: ### Builds a local docker image passing in the git information in as a label
+ifndef $(tag)
+	@echo "Specify the image tag on the command line with\n\tmake build tag=1.0.0"
+	@exit 1
+endif
 	docker build -t ${IMAGE_REFERENCE} \
 		--label build_date="${BUILD_DATE}" \
-		--label=branch="${BRANCH}" \
-		--label=version="${VERSION}" \
+		--label version="${VERSION}" \
 		.
 
 release: build ### Pushes the locally build docker image to the hub.docker.com registry
-	docker push ${IMAGE_REFERENCE}
+	git tag ${TAG}
+	docker push ${IMAGE_REFERENCE} latest
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,28 @@
-release:
-	docker build -t atlassianlabs/fluentd:$(tag) .
-	docker push atlassianlabs/fluentd:$(tag)
+.PHONY: clean
+.DEFAULT_GOAL := build
+
+GIT_HASH := $(shell git --no-pager show --format=%h --no-patch)
+BUILD_DATE := $(shell date +%Y%m%d-%H%M%S)
+BRANCH := $(shell git symbolic-ref --short HEAD)
+
+IS_DIRTY := $(shell ! [[ -z "$(git status --porcelain 2> /dev/null)" ]] && echo "-dirty")
+VERSION := ${GIT_HASH}${IS_DIRTY}
+TAG ?= ${VERSION}
+
+IMAGE_REPOSITORY := atlassianlabs/fluentd
+IMAGE_REFERENCE := ${IMAGE_REPOSITORY}:$(TAG)
+
+help: ### Dumps out all the target lines with suffixed comments
+	@cat < $(MAKEFILE_LIST) \
+		| awk -F':' '/^[a-zA-Z0-9][^$$#\/\t=]*:([^=]|$$)/ { split($$2, A, "###"); print $$1"|||"A[2]; }' \
+		| column -t -s'|||'
+
+build: ### Builds a local docker image passing in the git information in as a label
+	docker build -t ${IMAGE_REFERENCE} \
+		--label build_date="${BUILD_DATE}" \
+		--label=branch="${BRANCH}" \
+		--label=version="${VERSION}" \
+		.
+
+release: build ### Pushes the locally build docker image to the hub.docker.com registry
+	docker push ${IMAGE_REFERENCE}

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ help: ### Dumps out all the target lines with suffixed comments
 		| column -t -s'|||'
 
 build: ### Builds a local docker image passing in the git information in as a label
-ifndef $(tag)
-	@echo "Specify the image tag on the command line with\n\tmake build tag=1.0.0"
+ifndef tag
+	@echo "No value found for tag. Specify the image tag on the command line with\n\tmake build tag=1.0.0"
 	@exit 1
 endif
 	docker build -t ${IMAGE_REFERENCE} \
@@ -25,6 +25,6 @@ endif
 		.
 
 release: build ### Pushes the locally build docker image to the hub.docker.com registry
-	git tag ${TAG}
+	git tag $(tag)
 	docker push ${IMAGE_REFERENCE} latest
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ variables:
             -v /var/log:/fluentd/log -v `pwd`:/etc/fluent \
             atlassianlabs/fluentd:0.4.0
 
+# Build
+Testing changes locally
+```
+make build
+```
+
 # Release
 First register a Docker Hub account and ask one of the existing member to add you into the atlassianlabs team. Then you can run the following command to release a new version:
 


### PR DESCRIPTION
Wanting to take advantage of the nanosecond precision that comes with versions > 0.14 (as per https://github.com/fluent/fluentd/issues/461) this bumps the fluentd version as well as the https://github.com/atlassian/fluent-plugin-kinesis-aggregation version to take advantage of the increased precision.

Also fleshed out the Makefile and release process a bit to make is somewhat easier for new comers.